### PR TITLE
PackageInfo.g: add FGA as a needed dependency

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -88,7 +88,7 @@ PackageDoc := rec(
 
 Dependencies := rec(
 	GAP := ">= 4.10.2",
-	NeededOtherPackages := [ ],
+	NeededOtherPackages := [ ["fga", ">= 1.0"] ],
 	SuggestedOtherPackages := [ ],
 	ExternalConditions := [ ],
 ),


### PR DESCRIPTION
Needed for SmallGeneratingSet on subgroups of free groups
