### PR TITLE
Adjust two manual examples for GAP master

### DIFF
--- a/gap/Discreteness.gd
+++ b/gap/Discreteness.gd
@@ -112,8 +112,7 @@ DeclareAttribute( "InvolutiveCompatibilityCocycle" , IsLocalAction );
 #!
 #! @BeginExampleSession
 #! gap> F:=LocalAction(3,1,AlternatingGroup(3));;
-#! gap> z:=InvolutiveCompatibilityCocycle(F);
-#! MappingByFunction( <object>, Alt( [ 1 .. 3 ] ), function( s ) ... end )
+#! gap> z:=InvolutiveCompatibilityCocycle(F);;
 #! gap> mt:=RandomSource(IsMersenneTwister,1);;
 #! gap> a:=Random(mt,F);; dir:=Random(mt,[1..3]);;
 #! gap> a; Image(z,[a,dir]);
@@ -124,8 +123,8 @@ DeclareAttribute( "InvolutiveCompatibilityCocycle" , IsLocalAction );
 #! @BeginExampleSession
 #! gap> G:=LocalActionGamma(3,AlternatingGroup(3));
 #! Group([ (1,4,5)(2,3,6) ])
-#! gap> InvolutiveCompatibilityCocycle(G);
-#! MappingByFunction( <object>, Group([ (1,4,5)(2,3,6) ]), function( s ) ... end )
+#! gap> InvolutiveCompatibilityCocycle(G) <> fail;
+#! true
 #! gap> InvolutiveCompatibilityCocycle(AutBall(3,2));
 #! fail
 #! @EndExampleSession


### PR DESCRIPTION
The output for generic domains changed, which affects how the
result of `InvolutiveCompatibilityCocycle` is printed. This causes
spurious test failures. To fix this, stop printing this result.
