### PR TITLE
Tweak example to pass in newer GAP versions, too

### DIFF
--- a/gap/Examples.gd
+++ b/gap/Examples.gd
@@ -151,9 +151,9 @@ DeclareOperation( "LocalActionGamma" , [IsLocalAction, IsMapping] );
 #! gap> rho:=SignHomomorphism(F);;
 #! gap> H:=LocalActionPi(2,3,F,rho,[1]);;
 #! gap> z:=InvolutiveCompatibilityCocycle(H);;
-#! gap> LocalActionGamma(H,z);
-#! Group([ (), (), (1,12)(2,11)(3,9)(4,10)(5,6), (1,2)(5,12)(6,11)(7,10)(8,9), 
-#!   (1,7,12)(2,8,11)(3,6,10)(4,5,9) ])
+#! gap> g:=LocalActionGamma(H,z);;
+#! gap> [NrMovedPoints(g),TransitiveIdentification(g)];
+#! [ 12, 8 ]
 #! @EndExampleSession
 #! @EndGroup
 


### PR DESCRIPTION
On GAP master there recently was an improvement made to MinimalGeneratingSet
for non-pc groups. It turns out that this affects an example in the UGALY
manual which is also exercised by the test suite. This results in a different
output for `InvolutiveCompatibilityCocycle` and subsequently also for
`LocalActionGamma`, resulting in the test failure

This patch tweaks the example to only test the permutation type of the group
returned by `LocalActionGamma`.
